### PR TITLE
scipy.misc imread / imsave are depreciated

### DIFF
--- a/scripts/terrain.py
+++ b/scripts/terrain.py
@@ -4,7 +4,17 @@ gen = OpenSimplex()
 
 from forge.blade.lib import enums
 from matplotlib import pyplot as plt
-from scipy.misc import imread, imsave
+
+import sys
+
+try:
+    from imageio import imread, imsave
+except ImportError:
+    try:
+        from scipy.misc import imread, imsave
+    except ImportError:
+        print(sys.exc_info())
+
 from shutil import copyfile
 from copy import deepcopy
 import numpy as np


### PR DESCRIPTION
The imread / imsave functions from scipy.misc are removed in scipy >= 1.2.0 and are depreciated in >= 1.0.0 .  I switched the imports to use imageio according to the recommendation in scipy's documentation.  For those still using an older version of scipy, it will still fall back on the old imports.

See: https://docs.scipy.org/doc/scipy-1.2.1/reference/generated/scipy.misc.imread.html