### PR TITLE
fixing TypeError when assigning rating to agent

### DIFF
--- a/nmmo/lib/rating.py
+++ b/nmmo/lib/rating.py
@@ -76,7 +76,7 @@ class OpenSkillRating:
 
         teams = [[e] for e in list(self.ratings.values())]
         ratings = openskill.rate(teams, rank=ranks)
-        ratings = [openskill.create_rating(team[0]) for team in ratings]
+        ratings = [team[0] for team in ratings]
         for agent, rating in zip(self.ratings, ratings):
             self.ratings[agent] = rating
 


### PR DESCRIPTION
Hello, I encountered the below error while running the `demos.evaluate_sr`

```
  File "/home/kywch/nmmo-dev/baselines/demos/evaluate_sr.py", line 70, in <module>
    parallel_simulations(CORES, HORIZON)
  File "/home/kywch/nmmo-dev/baselines/demos/evaluate_sr.py", line 39, in parallel_simulations
    ratings = sr.update(
  File "/home/kywch/nmmo-dev/environment/nmmo/lib/rating.py", line 79, in update
    ratings = [openskill.create_rating(team[0]) for team in ratings]
  File "/home/kywch/nmmo-dev/environment/nmmo/lib/rating.py", line 79, in <listcomp>
    ratings = [openskill.create_rating(team[0]) for team in ratings]
  File "/home/kywch/nmmo-dev/.venv/lib/python3.9/site-packages/openskill/rate.py", line 218, in create_rating
    raise TypeError("Argument is already a 'Rating' object.")
TypeError: Argument is already a 'Rating' object.
```

The results of openskill.rate are already Rating objects, so I removed the redundant `openskill.create_rating()` 

After the fix, the error was gone, and I saw something like below.
```
Fisher: 1002.7   Herbalist: 993.00   Prospector: 1009.9   Carver: 1005.6   Alchemist: 998.85   Melee: 1008.0   Range: 1500   Mage: 981.31
Fisher: 1014.3   Herbalist: 1004.5   Prospector: 1021.5   Carver: 1010.4   Alchemist: 1010.2   Melee: 1019.4   Range: 1500   Mage: 975.92
Fisher: 1026.0   Herbalist: 1016.0   Prospector: 1033.0   Carver: 1018.7   Alchemist: 1014.4   Melee: 1015.7   Range: 1500   Mage: 966.15
Fisher: 1037.3   Herbalist: 1027.6   Prospector: 1044.5   Carver: 1030.3   Alchemist: 1025.7   Melee: 1027.1   Range: 1500   Mage: 977.55
Fisher: 1048.8   Herbalist: 1036.1   Prospector: 1030.0   Carver: 1041.9   Alchemist: 1030.7   Melee: 1026.7   Range: 1500   Mage: 989.11
Fisher: 1059.8   Herbalist: 1047.7   Prospector: 1041.4   Carver: 1053.1   Alchemist: 1042.0   Melee: 1038.2   Range: 1500   Mage: 1000.5
Fisher: 1070.7   Herbalist: 1059.1   Prospector: 1052.8   Carver: 1064.7   Alchemist: 1053.5   Melee: 1049.5   Range: 1500   Mage: 1011.9
Fisher: 1071.6   Herbalist: 1065.2   Prospector: 1049.7   Carver: 1073.6   Alchemist: 1065.0   Melee: 1035.1   Range: 1500   Mage: 1023.5
```

